### PR TITLE
DPPB-1088: Simplify PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,50 +1,15 @@
-## As a contributor
-By submitting this PR I confirm I have read and understood the Github Standards document and understand the role I play in ensuring standards, security, and assurance at DfT.
+## Summary
 
-## As a PR reviewer
-By accepting this PR I understand my responsibilities as described in the the Github standards document.
+[Describe the big picture of your changes here to make it clear what your pull request will change.] 
 
+## Proposed changes
 
-# Proposed changes
+[Make sure to explain the **what** e.g. the functionality it changes not the **how** e.g. what code you have written.]
 
-Describe the big picture of your changes here to make it clear what your pull request will change. Make sure to explain the **what** e.g. the functionality it changes not the **how** e.g. what code you have written.  If it fixes a bug or resolves a feature request, be sure to link to that issue.
+- 
+- 
+- 
 
-## Types of changes
+## Ticket
 
-What types of changes does your code introduce?
-_Put an `x` in the boxes that apply_
-
-- [ ] Bugfix (change which fixes an issue)
-- [ ] New feature (change which adds functionality)
-- [ ] Documentation Update (change to naming or other documentation)
-
-## Points I have checked in my code
-
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
-
-- [ ] I have added unit tests that prove my fix is effective or that my feature works
-- [ ] I have added necessary documentation (if appropriate)
-- [ ] I have checked that my changes have not broken any other functionality
-- [ ] I have linked to any issues this PR fixes
-
-## Points for review
-
-Add checkboxes here for any specific aspects of your PR you would like to be checked in peer review. If you don't specify anything here, the reviewer will check:
-
-- [ ] All of your unit tests pass
-- [ ] Your code is clear and easy to understand
-- [ ] You have documented any new features
-- [ ] They can run the code you have written
-- [ ] Your changes do not break any other functionality
-
-## Security considerations
-
-_Put an `x` in the boxes that apply. You should have considered all of these points before submitting a PR._
-
-- [ ] My code does not contain any secrets such as passwords, API keys, etc
-- [ ] I have not accidentally uploaded any data to Github
-- [ ] My code does not include any personal information such as names or email addresses
-
-## Who is reviewing this PR?
-
-Tag your reviewer here to ensure they get a notification!
+[Be sure to link the ticket here]


### PR DESCRIPTION
## Summary

Simplify the PR template to remove redundant text and only include the relevant information needed to enable reviewers to understand the changes being made and why.

# Proposed changes

- Update PR template to only have 3 sections: Summary, Proposed Changes and Ticket


## Ticket

https://jira.paconsultingatlassian.com/browse/DPPB-1088