### PR TITLE
DPPB-1122: Refactor coverage attributes and bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 /DfT.DTRO.DatabaseFeeder/bin/Debug/net8.0
 /DfT.DTRO.DatabaseFeeder/obj
 
-/TestReports
+**/TestResults
+**/TestReports
 **/Coverage
 **/temp

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/BaseTest.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/BaseTest.cs
@@ -4,7 +4,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public abstract class BaseTest : IAsyncLifetime
     {
         private static readonly Task _setUpBeforeTestRunAsync = SetUpBeforeTestRunAsync();

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/DtroUsers.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/DtroUsers.cs
@@ -4,7 +4,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.DataEntities
 {
-    [ExcludeFromCodeCoverage]
     public static class DtroUsers
     {
         public static async Task DeleteExistingUsersAsync(TestUser testUser)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Dtros.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Dtros.cs
@@ -3,7 +3,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.DataEntities
 {
-    [ExcludeFromCodeCoverage]
     public static class Dtros
     {
         public static void DeleteExistingDtros()

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Rules.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Rules.cs
@@ -2,7 +2,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.DataEntities
 {
-    [ExcludeFromCodeCoverage]
     public static class Rules
     {
         public static void DeleteExistingRules()

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Schemas.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataEntities/Schemas.cs
@@ -3,7 +3,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.DataEntities
 {
-    [ExcludeFromCodeCoverage]
     public static class Schemas
     {
         public static async Task DeleteExistingSchemasAsync(TestUser testUser)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataSetUp.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/DataSetUp.cs
@@ -1,6 +1,5 @@
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class DataSetUp
     {
         public static async Task ClearAllDataAsync(TestUser testUser)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/Enums.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/Enums.cs
@@ -1,6 +1,5 @@
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public class Enums
     {
         public enum EnvironmentType { Local, Dev, Test, Integration }

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/FileHelper.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/FileHelper.cs
@@ -1,6 +1,5 @@
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class FileHelper
     {
         public static void WriteStringToFile(string directory, string fileName, string stringToWrite)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/HttpRequestHelper.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/HttpRequestHelper.cs
@@ -7,7 +7,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class HttpRequestHelper
     {
         public static async Task<HttpResponseMessage> MakeHttpRequestAsync(HttpMethod method, string uri, Dictionary<string, string> headers = null, string body = null, string pathToJsonFile = null, bool printCurl = true)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/JsonHelper.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/JsonHelper.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class JsonHelper
     {
         public static async Task<string> GetIdFromResponseJsonAsync(HttpResponseMessage httpResponse)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/SqlQueries.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/SqlQueries.cs
@@ -3,7 +3,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class SqlQueries
     {
         public static void TruncateTable(string tableName)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/TestConfig.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/TestConfig.cs
@@ -3,7 +3,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.Enums;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class TestConfig
     {
         public static readonly string SchemaVersionUnderTest = "3.3.1";

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/TestUsers.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/Helpers/TestUsers.cs
@@ -1,6 +1,5 @@
 namespace DfT.DTRO.IntegrationTests.IntegrationTests.Helpers
 {
-    [ExcludeFromCodeCoverage]
     public static class TestUsers
     {
         public static TestUser GenerateUser(UserGroup userGroup)

--- a/Src/DfT.DTRO.IntegrationTests/IntegrationTests/SendDtroIntegrationTests.cs
+++ b/Src/DfT.DTRO.IntegrationTests/IntegrationTests/SendDtroIntegrationTests.cs
@@ -5,7 +5,6 @@ using static DfT.DTRO.IntegrationTests.IntegrationTests.Helpers.TestConfig;
 
 namespace DfT.DTRO.IntegrationTests.IntegrationTests;
 
-[ExcludeFromCodeCoverage]
 public class SendDtroIntegrationTests : BaseTest
 {
     public static IEnumerable<object[]> GetFileNames()

--- a/Src/DfT.DTRO/DfT.DTRO.csproj
+++ b/Src/DfT.DTRO/DfT.DTRO.csproj
@@ -1,64 +1,64 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-	<Description>DfT.DTRO</Description>
-	<Copyright>DfT</Copyright>
-	<TargetFramework>net8.0</TargetFramework>
-	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<PreserveCompilationContext>true</PreserveCompilationContext>
-	<AssemblyName>DfT.DTRO</AssemblyName>
-	<PackageId>DfT.DTRO</PackageId>
-	<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-	<Compile Remove="CustomErrors\**" />
-	<Compile Remove="Models\DtroSourceHistory\**" />
-	<Content Remove="CustomErrors\**" />
-	<Content Remove="Models\DtroSourceHistory\**" />
-	<EmbeddedResource Remove="CustomErrors\**" />
-	<EmbeddedResource Remove="Models\DtroSourceHistory\**" />
-	<None Remove="CustomErrors\**" />
-	<None Remove="Models\DtroSourceHistory\**" />
-  </ItemGroup>
-  <ItemGroup>
-	<Compile Remove="JsonLogic\DataBaseRuleSource.cs" />
-	<Compile Remove="Models\SchemaTemplate\SchemaResponse.cs" />
-  </ItemGroup>
-  <ItemGroup>
-	<PackageReference Include="DotSpatial.Projections" Version="4.0.656" />
-	  <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
-	  <PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.5.0" />
-	<PackageReference Include="JsonLogic" Version="4.0.4" />
-	<PackageReference Include="Microsoft.CodeAnalysis" Version="4.5.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-	<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
-	<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
-	<PackageReference Include="NetTopologySuite" Version="2.5.0" />
-	<PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-	<PackageReference Include="Npgsql" Version="8.0.3" />
-	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-	<PackageReference Include="ReportGenerator" Version="5.2.4" />
-	<PackageReference Include="Scrutor" Version="6.0.1" />
-	<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-	<PackageReference Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.7.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
-	<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-	<PackageReference Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-  <ItemGroup>
-	<Folder Include="Extensions\Exceptions\" />
-	<Folder Include="Logs\" />
-	<Folder Include="Models\Parameters\" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Description>DfT.DTRO</Description>
+		<Copyright>DfT</Copyright>
+		<TargetFramework>net8.0</TargetFramework>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<PreserveCompilationContext>true</PreserveCompilationContext>
+		<AssemblyName>DfT.DTRO</AssemblyName>
+		<PackageId>DfT.DTRO</PackageId>
+		<CodeAnalysisRuleSet></CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="CustomErrors\**" />
+		<Compile Remove="Models\DtroSourceHistory\**" />
+		<Content Remove="CustomErrors\**" />
+		<Content Remove="Models\DtroSourceHistory\**" />
+		<EmbeddedResource Remove="CustomErrors\**" />
+		<EmbeddedResource Remove="Models\DtroSourceHistory\**" />
+		<None Remove="CustomErrors\**" />
+		<None Remove="Models\DtroSourceHistory\**" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Remove="JsonLogic\DataBaseRuleSource.cs" />
+		<Compile Remove="Models\SchemaTemplate\SchemaResponse.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DotSpatial.Projections" Version="4.0.656" />
+		<PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+		<PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.5.0" />
+		<PackageReference Include="JsonLogic" Version="4.0.4" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.5.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
+		<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
+		<PackageReference Include="NetTopologySuite" Version="2.5.0" />
+		<PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
+		<PackageReference Include="Npgsql" Version="8.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+		<PackageReference Include="ReportGenerator" Version="5.2.4" />
+		<PackageReference Include="Scrutor" Version="6.0.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+		<PackageReference Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.7.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
+		<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
+	<ItemGroup>
+		<Folder Include="Extensions\Exceptions\" />
+		<Folder Include="Logs\" />
+		<Folder Include="Models\Parameters\" />
+	</ItemGroup>
 </Project>

--- a/Src/DfT.DTRO/Migrations/20230709213021_InitialCreate.cs
+++ b/Src/DfT.DTRO/Migrations/20230709213021_InitialCreate.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class InitialCreate : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20230710062156_NoAutogenerateId.cs
+++ b/Src/DfT.DTRO/Migrations/20230710062156_NoAutogenerateId.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class NoAutogenerateId : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20230717231737_SearchOptimisationFields.cs
+++ b/Src/DfT.DTRO/Migrations/20230717231737_SearchOptimisationFields.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class SearchOptimisationFields : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20230718083322_AggregateSearchOptimisationFields.cs
+++ b/Src/DfT.DTRO/Migrations/20230718083322_AggregateSearchOptimisationFields.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class AggregateSearchOptimisationFields : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20230721080815_OtherSearchOptimizationFields.cs
+++ b/Src/DfT.DTRO/Migrations/20230721080815_OtherSearchOptimizationFields.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class OtherSearchOptimizationFields : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20230804120231_RenameHaToTa.cs
+++ b/Src/DfT.DTRO/Migrations/20230804120231_RenameHaToTa.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Migrations;
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class RenameHaToTa : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240327094926_TemplateTables.cs
+++ b/Src/DfT.DTRO/Migrations/20240327094926_TemplateTables.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class TemplateTables : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240328120635_SchemaRulesCorrelation.cs
+++ b/Src/DfT.DTRO/Migrations/20240328120635_SchemaRulesCorrelation.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class SchemaRulesCorrelation : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240425091603_RulesChangedToText.cs
+++ b/Src/DfT.DTRO/Migrations/20240425091603_RulesChangedToText.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 namespace DfT.DTRO.Migrations;
-[ExcludeFromCodeCoverage]
 public partial class RulesChangedToText : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240606215903_ActionTypeAndReferenceToSourceAndProvision.cs
+++ b/Src/DfT.DTRO/Migrations/20240606215903_ActionTypeAndReferenceToSourceAndProvision.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class ActionTypeAndReferenceToSourceAndProvision : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240611134713_RemoveActionTypeAndReferenceFromSourceAndProvision.cs
+++ b/Src/DfT.DTRO/Migrations/20240611134713_RemoveActionTypeAndReferenceFromSourceAndProvision.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class RemoveActionTypeAndReferenceFromSourceAndProvision : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240612105620_DTROHistoryTableCreated.cs
+++ b/Src/DfT.DTRO/Migrations/20240612105620_DTROHistoryTableCreated.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class DTROHistoryTableCreated : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240617101245_ChangeTraToTraCreatorAndAddTraOwner.cs
+++ b/Src/DfT.DTRO/Migrations/20240617101245_ChangeTraToTraCreatorAndAddTraOwner.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class ChangeTraToTraCreatorAndAddTraOwner : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240617150331_ChangeTaToTra.cs
+++ b/Src/DfT.DTRO/Migrations/20240617150331_ChangeTaToTra.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class ChangeTaToTra : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240619134210_AdjustDtroHistoryEntity.cs
+++ b/Src/DfT.DTRO/Migrations/20240619134210_AdjustDtroHistoryEntity.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AdjustDtroHistoryEntity : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240619152601_AddDtroIdToDtroHistory.cs
+++ b/Src/DfT.DTRO/Migrations/20240619152601_AddDtroIdToDtroHistory.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AddDtroIdToDtroHistory : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240701093628_Metrics.cs
+++ b/Src/DfT.DTRO/Migrations/20240701093628_Metrics.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class Metrics : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240708141047_AddSwaCodesTable.cs
+++ b/Src/DfT.DTRO/Migrations/20240708141047_AddSwaCodesTable.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AddSwaCodesTable : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240708153050_AdjustSwaCodesTable.cs
+++ b/Src/DfT.DTRO/Migrations/20240708153050_AdjustSwaCodesTable.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AdjustSwaCodesTable : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240726140900_SwaCodesIsActive.cs
+++ b/Src/DfT.DTRO/Migrations/20240726140900_SwaCodesIsActive.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class SwaCodesIsActive : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240805085515_AddSystemConfig.cs
+++ b/Src/DfT.DTRO/Migrations/20240805085515_AddSystemConfig.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AddSystemConfig : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240819153005_DtroUsers.cs
+++ b/Src/DfT.DTRO/Migrations/20240819153005_DtroUsers.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class DtroUsers : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240821105810_IsTestAddedToConfig.cs
+++ b/Src/DfT.DTRO/Migrations/20240821105810_IsTestAddedToConfig.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class IsTestAddedToConfig : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20240822083155_UserGroupAddedToMetrics.cs
+++ b/Src/DfT.DTRO/Migrations/20240822083155_UserGroupAddedToMetrics.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class UserGroupAddedToMetrics : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20250129131007_AddRegulatedPlaceTypesDtroProperty.cs
+++ b/Src/DfT.DTRO/Migrations/20250129131007_AddRegulatedPlaceTypesDtroProperty.cs
@@ -4,7 +4,6 @@
 
 namespace DfT.DTRO.Migrations
 {
-    [ExcludeFromCodeCoverage]
     public partial class AddRegulatedPlaceTypesDtroProperty : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Src/DfT.DTRO/Migrations/20250211123313_UserAndUserStatusEntitiesAdded.cs
+++ b/Src/DfT.DTRO/Migrations/20250211123313_UserAndUserStatusEntitiesAdded.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class UserAndUserStatusEntitiesAdded : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/20250211125053_AddDigitalServiceProviderEntity.cs
+++ b/Src/DfT.DTRO/Migrations/20250211125053_AddDigitalServiceProviderEntity.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class AddDigitalServiceProviderEntity : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/20250211130318_AddApplicationTypeEntity.cs
+++ b/Src/DfT.DTRO/Migrations/20250211130318_AddApplicationTypeEntity.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class AddApplicationTypeEntity : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/20250211131918_AddMoreEntities.cs
+++ b/Src/DfT.DTRO/Migrations/20250211131918_AddMoreEntities.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class AddMoreEntities : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/20250211133649_AddTheRemainingEntities.cs
+++ b/Src/DfT.DTRO/Migrations/20250211133649_AddTheRemainingEntities.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class AddTheRemainingEntities : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/20250224174303_FixEntityRelationships.cs
+++ b/Src/DfT.DTRO/Migrations/20250224174303_FixEntityRelationships.cs
@@ -5,7 +5,6 @@
 namespace DfT.DTRO.Migrations
 {
     /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
     public partial class FixEntityRelationships : Migration
     {
         /// <inheritdoc />

--- a/Src/DfT.DTRO/Migrations/DtroContextModelSnapshot.cs
+++ b/Src/DfT.DTRO/Migrations/DtroContextModelSnapshot.cs
@@ -13,7 +13,6 @@ using NpgsqlTypes;
 namespace DfT.DTRO.Migrations
 {
     [DbContext(typeof(DtroContext))]
-    [ExcludeFromCodeCoverage]
     partial class DtroContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/Src/DfT.DTRO/Migrations/SeedData.cs
+++ b/Src/DfT.DTRO/Migrations/SeedData.cs
@@ -1,6 +1,5 @@
 ﻿namespace DfT.DTRO.Migrations;
 
-[ExcludeFromCodeCoverage]
 public static class SeedData
 {
 

--- a/Src/DfT.DTRO/Models/DataBase/Application.cs
+++ b/Src/DfT.DTRO/Models/DataBase/Application.cs
@@ -1,8 +1,8 @@
 ﻿namespace DfT.DTRO.Models.DataBase;
-
 /// <summary>
 /// Wrapper for Application
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class Application
 {
@@ -51,7 +51,7 @@ public class Application
     /// </summary>
     public List<DTRO> Dtros { get; set; }
 
-    public Guid PurposeId { get; set; }  
+    public Guid PurposeId { get; set; }
     public ApplicationPurpose Purpose { get; set; }
 
     public Guid UserId { get; set; }

--- a/Src/DfT.DTRO/Models/DataBase/ApplicationPurpose.cs
+++ b/Src/DfT.DTRO/Models/DataBase/ApplicationPurpose.cs
@@ -1,8 +1,8 @@
 ﻿namespace DfT.DTRO.Models.DataBase;
-
 /// <summary>
 /// Wrapper for Application Purpose
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class ApplicationPurpose
 {

--- a/Src/DfT.DTRO/Models/DataBase/ApplicationType.cs
+++ b/Src/DfT.DTRO/Models/DataBase/ApplicationType.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for application type
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class ApplicationType
 {

--- a/Src/DfT.DTRO/Models/DataBase/BaseEntity.cs
+++ b/Src/DfT.DTRO/Models/DataBase/BaseEntity.cs
@@ -3,6 +3,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Base entity
 /// </summary>
+[ExcludeFromCodeCoverage]
 public class BaseEntity
 {
     /// <summary>

--- a/Src/DfT.DTRO/Models/DataBase/DTRO.cs
+++ b/Src/DfT.DTRO/Models/DataBase/DTRO.cs
@@ -6,6 +6,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for D-TRO submission.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class DTRO
 {

--- a/Src/DfT.DTRO/Models/DataBase/DTROHistory.cs
+++ b/Src/DfT.DTRO/Models/DataBase/DTROHistory.cs
@@ -6,6 +6,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for D-TRO history.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class DTROHistory
 {

--- a/Src/DfT.DTRO/Models/DataBase/DigitalServiceProvider.cs
+++ b/Src/DfT.DTRO/Models/DataBase/DigitalServiceProvider.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for Digital Service Provider
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class DigitalServiceProvider
 {

--- a/Src/DfT.DTRO/Models/DataBase/DtroUser.cs
+++ b/Src/DfT.DTRO/Models/DataBase/DtroUser.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for Street Work Manager codes.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class DtroUser
 {

--- a/Src/DfT.DTRO/Models/DataBase/Metric.cs
+++ b/Src/DfT.DTRO/Models/DataBase/Metric.cs
@@ -3,6 +3,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for Metric
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class Metric
 {

--- a/Src/DfT.DTRO/Models/DataBase/RulesTemplate.cs
+++ b/Src/DfT.DTRO/Models/DataBase/RulesTemplate.cs
@@ -5,6 +5,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for a Rule.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class RuleTemplate
 {

--- a/Src/DfT.DTRO/Models/DataBase/SchemaTemplate.cs
+++ b/Src/DfT.DTRO/Models/DataBase/SchemaTemplate.cs
@@ -6,6 +6,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for a Schema.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class SchemaTemplate
 {

--- a/Src/DfT.DTRO/Models/DataBase/SystemConfig.cs
+++ b/Src/DfT.DTRO/Models/DataBase/SystemConfig.cs
@@ -1,5 +1,6 @@
 ﻿namespace DfT.DTRO.Models.DataBase;
 
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class SystemConfig
 {

--- a/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthority.cs
+++ b/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthority.cs
@@ -3,6 +3,7 @@ namespace DfT.DTRO.Models.DataBase;
 /// <summary>
 /// Wrapper for Traffic Regulation Authority 
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class TrafficRegulationAuthority
 {

--- a/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthorityDigitalServiceProvider.cs
+++ b/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthorityDigitalServiceProvider.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for Traffic Regulation Authority relationship with Digital Service Provider
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class TrafficRegulationAuthorityDigitalServiceProvider
 {

--- a/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthorityDigitalServiceProviderStatus.cs
+++ b/Src/DfT.DTRO/Models/DataBase/TrafficRegulationAuthorityDigitalServiceProviderStatus.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for Traffic Regulation Authority Digital Service Provider Status
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class TrafficRegulationAuthorityDigitalServiceProviderStatus
 {

--- a/Src/DfT.DTRO/Models/DataBase/User.cs
+++ b/Src/DfT.DTRO/Models/DataBase/User.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for User table
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class User
 {

--- a/Src/DfT.DTRO/Models/DataBase/UserStatus.cs
+++ b/Src/DfT.DTRO/Models/DataBase/UserStatus.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Wrapper for User Status table
 /// </summary>
+[ExcludeFromCodeCoverage]
 [DataContract]
 public class UserStatus
 {

--- a/Src/DfT.DTRO/Startup.cs
+++ b/Src/DfT.DTRO/Startup.cs
@@ -1,4 +1,3 @@
-using DfT.DTRO.Apis.Clients;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Integration/BoundingBoxJsonConverterTests_CodeiumTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Integration/BoundingBoxJsonConverterTests_CodeiumTests.cs
@@ -2,7 +2,6 @@
 
 namespace Dft.DTRO.Tests.CodeiumTests.Integration;
 
-[ExcludeFromCodeCoverage]
 public class BoundingBoxJsonConverterTests
 {
     private readonly JsonSerializer _serializer;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Integration/DTROController_CodeiumTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Integration/DTROController_CodeiumTests.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Converters;
 
 namespace DfT.DTRO.Tests.CodeiumTests.Integration;
 
-[ExcludeFromCodeCoverage]
 public class DTROsController_Codeium_Tests : IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly Mock<IDtroService> _mockDtroService;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Integration/SchemaControllers_CodeiumTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Integration/SchemaControllers_CodeiumTests.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Converters;
 
 namespace DfT.DTRO.Tests.CodeiumTests.Integration;
 
-[ExcludeFromCodeCoverage]
 public class SchemaController_Codeium_Tests : IClassFixture<WebApplicationFactory<Program>>
 {
     private const string SchemaVersion = "3.2.0";

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Metrics/Controller/MetricsControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Metrics/Controller/MetricsControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Metrics.Controller;
 
-[ExcludeFromCodeCoverage]
 public class MetricsControllerTests
 {
     private readonly MetricsController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Metrics/Service/MetricsServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Metrics/Service/MetricsServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Metrics.Service;
 
-[ExcludeFromCodeCoverage]
 public class MetricsServiceTests
 {
     private readonly MetricRequest _metricRequest = new()

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerCreateTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerCreateTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Controller;
 
-[ExcludeFromCodeCoverage]
 public class RulesControllerCreateTests
 {
     private readonly RulesController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerGetRuleByIdTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerGetRuleByIdTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Controller;
 
-[ExcludeFromCodeCoverage]
 public class RulesControllerGetRuleByIdTests
 {
     private readonly RulesController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerGetRulesTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerGetRulesTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Controller;
 
-[ExcludeFromCodeCoverage]
 public class RulesControllerTests
 {
     private readonly RulesController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerUpdateTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerUpdateTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Controller;
 
-[ExcludeFromCodeCoverage]
 public class RulesControllerUpdateTests
 {
     private readonly RulesController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerVersionTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Controller/RulesControllerVersionTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Controller;
 
-[ExcludeFromCodeCoverage]
 public class RulesControllerVersionTests
 {
     private readonly RulesController _controller;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Mapping/RulesTemplateMappingServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Mapping/RulesTemplateMappingServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Mapping;
 
-[ExcludeFromCodeCoverage]
 public class RulesTemplateMappingServiceTests
 {
     private readonly RuleTemplateMappingService _service = new();

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Service/RuleTemplateServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Rules/Service/RuleTemplateServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Rules.Service;
 
-[ExcludeFromCodeCoverage]
 public class RuleTemplateServiceTests
 {
     private readonly Mock<IDtroDal> _mockDtroDal;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/SystemConfig/Controller/SystemConfigControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/SystemConfig/Controller/SystemConfigControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.SystemConfig.Controller;
 
-[ExcludeFromCodeCoverage]
 public class SystemConfigControllerTests
 {
     private readonly Mock<IAppIdMapperService> _mockXappIdMapperService;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/SystemConfig/Service/SystemConfigServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/SystemConfig/Service/SystemConfigServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.SystemConfig.Service;
 
-[ExcludeFromCodeCoverage]
 public class SystemConfigServiceTests
 {
     private readonly Mock<ISystemConfigDal> _mockSystemConfigDal;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerCreateFromBodyTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerCreateFromBodyTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Users.Controller;
 
-[ExcludeFromCodeCoverage]
 public class UserControllerCreateFromBodyTests
 {
     private readonly Mock<IDtroUserService> _traServiceMock;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerGetSwaCodesTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerGetSwaCodesTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Users.Controller;
 
-[ExcludeFromCodeCoverage]
 public class UserControllerGetSwaCodesTests
 {
     private readonly Mock<IDtroUserService> _traServiceMock;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerSearchSwaCodesTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Users/Controller/UserControllerSearchSwaCodesTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Users.Controller;
 
-[ExcludeFromCodeCoverage]
 public class UserControllerSearchSwaCodesTests
 {
     private readonly Mock<IDtroUserService> _traServiceMock;

--- a/Src/Dft.DTRO.Tests/CodeiumTests/Users/Service/UserServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/CodeiumTests/Users/Service/UserServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.CodeiumTests.Users.Service;
 
-[ExcludeFromCodeCoverage]
 public class UserServiceTests
 {
     private readonly Mock<IDtroUserDal> _mockDtroUserDal;

--- a/Src/Dft.DTRO.Tests/ControllerTests/ApplicationControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/ControllerTests/ApplicationControllerTests.cs
@@ -1,6 +1,5 @@
 using Dft.DTRO.Tests.Fixtures;
 
-[ExcludeFromCodeCoverage]
 public class ApplicationControllerTests : IClassFixture<ApplicationControllerTestFixture>
 {
     private readonly Mock<IApplicationService> _mockApplicationService;

--- a/Src/Dft.DTRO.Tests/ControllerTests/AuthControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/ControllerTests/AuthControllerTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.ControllerTests;
 
-[ExcludeFromCodeCoverage]
 public class AuthControllerTests
 {
     private readonly Mock<IAuthService> _mockAuthService = new();

--- a/Src/Dft.DTRO.Tests/ControllerTests/DTROsControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/ControllerTests/DTROsControllerTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.ControllerTests;
 
-[ExcludeFromCodeCoverage]
 public class DTROsControllerTests
 {
     private readonly Mock<IDtroService> _mockDtroService = new();

--- a/Src/Dft.DTRO.Tests/ControllerTests/SchemasControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/ControllerTests/SchemasControllerTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.ControllerTests;
 
-[ExcludeFromCodeCoverage]
 //TODO: The entire class needs refactoring
 public class SchemasControllerTests
     : IClassFixture<WebApplicationFactory<Program>>

--- a/Src/Dft.DTRO.Tests/ControllerTests/TraControllerTests.cs
+++ b/Src/Dft.DTRO.Tests/ControllerTests/TraControllerTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.ControllerTests;
 
-[ExcludeFromCodeCoverage]
 public class TraControllerTests
 {
     private readonly Mock<ITraService> _mockTraService = new();

--- a/Src/Dft.DTRO.Tests/DALTests/Application/ApplicationDalTests.cs
+++ b/Src/Dft.DTRO.Tests/DALTests/Application/ApplicationDalTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.DALTests
 {
-    [ExcludeFromCodeCoverage]
     public class ApplicationDalTests : IDisposable
     {
         private readonly DtroContext _context;

--- a/Src/Dft.DTRO.Tests/Fixtures/ApplicationControllerFixtures.cs
+++ b/Src/Dft.DTRO.Tests/Fixtures/ApplicationControllerFixtures.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.Fixtures
 {
-    [ExcludeFromCodeCoverage]
     public class ApplicationControllerTestFixture
     {
         public ControllerContext ControllerContext { get; }

--- a/Src/Dft.DTRO.Tests/Mocks/MockHttpContext.cs
+++ b/Src/Dft.DTRO.Tests/Mocks/MockHttpContext.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.Mocks;
 
-[ExcludeFromCodeCoverage]
 public static class MockHttpContext
 {
     public static Mock<HttpContext> Setup()

--- a/Src/Dft.DTRO.Tests/Mocks/MockLogger.cs
+++ b/Src/Dft.DTRO.Tests/Mocks/MockLogger.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.Mocks;
 
-[ExcludeFromCodeCoverage]
 public static class MockLogger
 {
     public static ILogger<T> Setup<T>()

--- a/Src/Dft.DTRO.Tests/Mocks/MockTestObjects.cs
+++ b/Src/Dft.DTRO.Tests/Mocks/MockTestObjects.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.Mocks;
 
-[ExcludeFromCodeCoverage]
 public static class MockTestObjects
 {
     public static IFormFile TestFile

--- a/Src/Dft.DTRO.Tests/Mocks/MockUserRepository.cs
+++ b/Src/Dft.DTRO.Tests/Mocks/MockUserRepository.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.Mocks;
 
-[ExcludeFromCodeCoverage]
 public static class MockUserRepository
 {
     public static Mock<IDtroUserDal> Setup()

--- a/Src/Dft.DTRO.Tests/ServicesTests/Application/ApplicationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Application/ApplicationServiceTests.cs
@@ -1,6 +1,5 @@
 namespace Dft.DTRO.Tests.ServicesTests.Application;
 
-[ExcludeFromCodeCoverage]
 public class ApplicationServiceTests
 {
     private readonly Mock<IApplicationDal> _applicationDalMock;

--- a/Src/Dft.DTRO.Tests/ServicesTests/DTROs/GetDtrosTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/DTROs/GetDtrosTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.DTROs;
 
-[ExcludeFromCodeCoverage]
 public class GetDtrosTests
 {
     private readonly Mock<IDtroUserDal> _mockDtroUserDal = new();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Tra/TraServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Tra/TraServiceTests.cs
@@ -1,11 +1,10 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Tra;
 
-[ExcludeFromCodeCoverage]
 public class TraServiceTests
 {
     private readonly Mock<ITraDal> _mockTraDal = new();
     private readonly Mock<IDtroMappingService> _mockDtroMappingService = new();
-    
+
     private readonly ITraService _sut;
 
     public TraServiceTests()

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/ConditionValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/ConditionValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class ConditionValidationServiceTests
 {
     private readonly IConditionValidationService _sut = new ConditionValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/ElementaryStreetUnitValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/ElementaryStreetUnitValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class ElementaryStreetUnitValidationServiceTests
 {
     private readonly IElementaryStreetUnitValidationService _sut = new ElementaryStreetUnitValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/ExternalReferenceValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/ExternalReferenceValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class ExternalReferenceValidationServiceTests
 {
     private readonly IExternalReferenceValidationService _sut = new ExternalReferenceValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/GeometryValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/GeometryValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class GeometryValidationServiceTests
 {
     private readonly IGeometryValidationService _sut = new GeometryValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/GeometryValidationTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/GeometryValidationTests.cs
@@ -2,7 +2,6 @@
 
 namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class GeometryValidationTests
 {
     private readonly IGeometryValidation _sut;

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/JsonLogicValidationTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/JsonLogicValidationTests.cs
@@ -2,7 +2,6 @@
 
 namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class JsonLogicValidationTests
 {
     private readonly Mock<IRuleTemplateDal> _ruleDal = new();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/JsonSchemaValidationTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/JsonSchemaValidationTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class JsonSchemaValidationTests
 {
     private const string ExampleFilesForSchema311 = "../../../TestFiles/D-TROs/3.1.1";

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/ProvisionValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/ProvisionValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class ProvisionValidationServiceTests
 {
     private readonly IProvisionValidationService _sut = new ProvisionValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateLineCollectionValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateLineCollectionValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class RateLineCollectionValidationServiceTests
 {
     private readonly IRateLineCollectionValidationService _sut = new RateLineCollectionValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateLineValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateLineValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class RateLineValidationServiceTests
 {
     private readonly IRateLineValidationService _sut = new RateLineValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateTableValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/RateTableValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class RateTableValidationServiceTests
 {
     private readonly IRateTableValidationService _sut = new RateTableValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/RegulatedPlaceValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/RegulatedPlaceValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class RegulatedPlaceValidationServiceTests
 {
     private readonly IRegulatedPlaceValidationService _sut = new RegulatedPlaceValidationService();

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/RegulationValidationTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/RegulationValidationTests.cs
@@ -1,14 +1,13 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class RegulationValidationTests
 {
-    private readonly IRegulationValidation _sut = new RegulationValidation();
+  private readonly IRegulationValidation _sut = new RegulationValidation();
 
-    [Fact]
-    public void ValidateRegulationWhenIsDynamicIsTrueReturnsNoErrors()
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Fact]
+  public void ValidateRegulationWhenIsDynamicIsTrueReturnsNoErrors()
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -24,14 +23,14 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Empty(actual);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Empty(actual);
+  }
 
-    [Fact]
-    public void ValidateRegulationWhenIsDynamicIsFalseReturnsNoErrors()
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Fact]
+  public void ValidateRegulationWhenIsDynamicIsFalseReturnsNoErrors()
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -47,17 +46,17 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Empty(actual);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Empty(actual);
+  }
 
-    [Theory]
-    [InlineData("Europe/London", 0)]
-    [InlineData("", 1)]
-    [InlineData(null, 1)]
-    public void ValidateRegulationTimeZone(string timeZone, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("Europe/London", 0)]
+  [InlineData("", 1)]
+  [InlineData(null, 1)]
+  public void ValidateRegulationTimeZone(string timeZone, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -73,26 +72,26 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
 
 
-    [Theory]
-    [InlineData(10, 0)]
-    [InlineData(20, 0)]
-    [InlineData(30, 0)]
-    [InlineData(40, 0)]
-    [InlineData(50, 0)]
-    [InlineData(60, 0)]
-    [InlineData(70, 0)]
-    [InlineData(80, 1)]
-    [InlineData(55, 1)]
-    [InlineData(0, 1)]
-    public void ValidateSpeedLimitValueBasedSpeedValue(int mphValue, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData(10, 0)]
+  [InlineData(20, 0)]
+  [InlineData(30, 0)]
+  [InlineData(40, 0)]
+  [InlineData(50, 0)]
+  [InlineData(60, 0)]
+  [InlineData(70, 0)]
+  [InlineData(80, 1)]
+  [InlineData(55, 1)]
+  [InlineData(0, 1)]
+  public void ValidateSpeedLimitValueBasedSpeedValue(int mphValue, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -112,18 +111,18 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("maximumSpeedLimit", 0)]
-    [InlineData("minimumSpeedLimit", 0)]
-    [InlineData("nationalSpeedLimitWellLitStreetDefault", 0)]
-    [InlineData("unknown", 1)]
-    public void ValidateSpeedLimitValueBasedSpeedType(string type, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("maximumSpeedLimit", 0)]
+  [InlineData("minimumSpeedLimit", 0)]
+  [InlineData("nationalSpeedLimitWellLitStreetDefault", 0)]
+  [InlineData("unknown", 1)]
+  public void ValidateSpeedLimitValueBasedSpeedType(string type, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -143,18 +142,18 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("nationalSpeedLimitDualCarriageway", 0)]
-    [InlineData("nationalSpeedLimitSingleCarriageway", 0)]
-    [InlineData("nationalSpeedLimitMotorway", 0)]
-    [InlineData("unknown", 1)]
-    public void ValidateSpeedLimitProfileBasedSpeedType(string type, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("nationalSpeedLimitDualCarriageway", 0)]
+  [InlineData("nationalSpeedLimitSingleCarriageway", 0)]
+  [InlineData("nationalSpeedLimitMotorway", 0)]
+  [InlineData("unknown", 1)]
+  public void ValidateSpeedLimitProfileBasedSpeedType(string type, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -173,80 +172,80 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("dimensionMaximumHeightStructural", 0)]
-    [InlineData("dimensionMaximumHeightWithTRO", 0)]
-    [InlineData("dimensionMaximumLength", 0)]
-    [InlineData("dimensionMaximumWeightEnvironmental", 0)]
-    [InlineData("dimensionMaximumWeightStructural", 0)]
-    [InlineData("dimensionMaximumWidth", 0)]
-    [InlineData("bannedMovementNoEntry", 0)]
-    [InlineData("bannedMovementNoLeftTurn", 0)]
-    [InlineData("bannedMovementNoRightTurn", 0)]
-    [InlineData("bannedMovementNoUTurn", 0)]
-    [InlineData("mandatoryDirectionAheadOnly", 0)]
-    [InlineData("mandatoryDirectionLeftTurnOnly", 0)]
-    [InlineData("mandatoryDirectionOneWay", 0)]
-    [InlineData("mandatoryDirectionRightTurnOnly", 0)]
-    [InlineData("movementOrderNoOvertaking", 0)]
-    [InlineData("movementOrderPriorityOverOncomingTraffic", 0)]
-    [InlineData("movementOrderProhibitedAccess", 0)]
-    [InlineData("kerbsideDisabledBadgeHoldersOnly", 0)]
-    [InlineData("kerbsideRuralClearway", 0)]
-    [InlineData("kerbsideLimitedWaiting", 0)]
-    [InlineData("kerbsideLoadingPlace", 0)]
-    [InlineData("kerbsideMotorcycleParkingPlace", 0)]
-    [InlineData("kerbsideNoLoading", 0)]
-    [InlineData("kerbsideNoStopping", 0)]
-    [InlineData("kerbsideNoWaiting", 0)]
-    [InlineData("kerbsideTaxiRank", 0)]
-    [InlineData("kerbsideSchoolKeepClearYellowZigZagMandatory", 0)]
-    [InlineData("kerbsideLoadingBay", 0)]
-    [InlineData("kerbsideOtherYellowZigZagMandatory", 0)]
-    [InlineData("kerbsidePermitParkingArea", 0)]
-    [InlineData("kerbsideParkingPlace", 0)]
-    [InlineData("kerbsideUrbanClearway", 0)]
-    [InlineData("kerbsideRedRouteClearway", 0)]
-    [InlineData("kerbsidePaymentParkingPlace", 0)]
-    [InlineData("kerbsidePermitParkingPlace", 0)]
-    [InlineData("kerbsideFootwayParking", 0)]
-    [InlineData("kerbsideControlledParkingZone", 0)]
-    [InlineData("kerbsideRestrictedParkingZone", 0)]
-    [InlineData("nonOrderKerbsideBusStop", 0)]
-    [InlineData("nonOrderMovementBoxJunction", 0)]
-    [InlineData("nonOrderKerbsidePedestrianCrossing", 0)]
-    [InlineData("miscBusGate", 0)]
-    [InlineData("miscBusLaneWithTrafficFlow", 0)]
-    [InlineData("miscBusOnlyStreet", 0)]
-    [InlineData("miscContraflowBusLane", 0)]
-    [InlineData("miscCongestionLowEmissionZone", 0)]
-    [InlineData("miscCycleLane", 0)]
-    [InlineData("miscPedestrianZone", 0)]
-    [InlineData("miscRoadClosure", 0)]
-    [InlineData("miscLaneClosure", 0)]
-    [InlineData("miscContraflow", 0)]
-    [InlineData("miscFootwayClosure", 0)]
-    [InlineData("miscCycleLaneClosure", 0)]
-    [InlineData("miscTemporaryParkingRestriction", 0)]
-    [InlineData("miscSuspensionOfOneWay", 0)]
-    [InlineData("miscSuspensionOfParkingRestriction", 0)]
-    [InlineData("miscSuspensionOfWeightRestriction", 0)]
-    [InlineData("miscSuspensionOfBusway", 0)]
-    [InlineData("miscTemporarySpeedLimit", 0)]
-    [InlineData("miscRoadClosureCrossingPoint", 0)]
-    [InlineData("miscBaySuspension", 0)]
-    [InlineData("miscTemporaryParkingBay", 0)]
-    [InlineData("miscPROWClosure", 0)]
-    [InlineData("kerbsideDoubleRedLines", 0)]
-    [InlineData("kerbsideSingleRedLines", 0)]
-    [InlineData("unknown", 1)]
-    public void ValidateGeneralRegulationRegulationType(string regulationType, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("dimensionMaximumHeightStructural", 0)]
+  [InlineData("dimensionMaximumHeightWithTRO", 0)]
+  [InlineData("dimensionMaximumLength", 0)]
+  [InlineData("dimensionMaximumWeightEnvironmental", 0)]
+  [InlineData("dimensionMaximumWeightStructural", 0)]
+  [InlineData("dimensionMaximumWidth", 0)]
+  [InlineData("bannedMovementNoEntry", 0)]
+  [InlineData("bannedMovementNoLeftTurn", 0)]
+  [InlineData("bannedMovementNoRightTurn", 0)]
+  [InlineData("bannedMovementNoUTurn", 0)]
+  [InlineData("mandatoryDirectionAheadOnly", 0)]
+  [InlineData("mandatoryDirectionLeftTurnOnly", 0)]
+  [InlineData("mandatoryDirectionOneWay", 0)]
+  [InlineData("mandatoryDirectionRightTurnOnly", 0)]
+  [InlineData("movementOrderNoOvertaking", 0)]
+  [InlineData("movementOrderPriorityOverOncomingTraffic", 0)]
+  [InlineData("movementOrderProhibitedAccess", 0)]
+  [InlineData("kerbsideDisabledBadgeHoldersOnly", 0)]
+  [InlineData("kerbsideRuralClearway", 0)]
+  [InlineData("kerbsideLimitedWaiting", 0)]
+  [InlineData("kerbsideLoadingPlace", 0)]
+  [InlineData("kerbsideMotorcycleParkingPlace", 0)]
+  [InlineData("kerbsideNoLoading", 0)]
+  [InlineData("kerbsideNoStopping", 0)]
+  [InlineData("kerbsideNoWaiting", 0)]
+  [InlineData("kerbsideTaxiRank", 0)]
+  [InlineData("kerbsideSchoolKeepClearYellowZigZagMandatory", 0)]
+  [InlineData("kerbsideLoadingBay", 0)]
+  [InlineData("kerbsideOtherYellowZigZagMandatory", 0)]
+  [InlineData("kerbsidePermitParkingArea", 0)]
+  [InlineData("kerbsideParkingPlace", 0)]
+  [InlineData("kerbsideUrbanClearway", 0)]
+  [InlineData("kerbsideRedRouteClearway", 0)]
+  [InlineData("kerbsidePaymentParkingPlace", 0)]
+  [InlineData("kerbsidePermitParkingPlace", 0)]
+  [InlineData("kerbsideFootwayParking", 0)]
+  [InlineData("kerbsideControlledParkingZone", 0)]
+  [InlineData("kerbsideRestrictedParkingZone", 0)]
+  [InlineData("nonOrderKerbsideBusStop", 0)]
+  [InlineData("nonOrderMovementBoxJunction", 0)]
+  [InlineData("nonOrderKerbsidePedestrianCrossing", 0)]
+  [InlineData("miscBusGate", 0)]
+  [InlineData("miscBusLaneWithTrafficFlow", 0)]
+  [InlineData("miscBusOnlyStreet", 0)]
+  [InlineData("miscContraflowBusLane", 0)]
+  [InlineData("miscCongestionLowEmissionZone", 0)]
+  [InlineData("miscCycleLane", 0)]
+  [InlineData("miscPedestrianZone", 0)]
+  [InlineData("miscRoadClosure", 0)]
+  [InlineData("miscLaneClosure", 0)]
+  [InlineData("miscContraflow", 0)]
+  [InlineData("miscFootwayClosure", 0)]
+  [InlineData("miscCycleLaneClosure", 0)]
+  [InlineData("miscTemporaryParkingRestriction", 0)]
+  [InlineData("miscSuspensionOfOneWay", 0)]
+  [InlineData("miscSuspensionOfParkingRestriction", 0)]
+  [InlineData("miscSuspensionOfWeightRestriction", 0)]
+  [InlineData("miscSuspensionOfBusway", 0)]
+  [InlineData("miscTemporarySpeedLimit", 0)]
+  [InlineData("miscRoadClosureCrossingPoint", 0)]
+  [InlineData("miscBaySuspension", 0)]
+  [InlineData("miscTemporaryParkingBay", 0)]
+  [InlineData("miscPROWClosure", 0)]
+  [InlineData("kerbsideDoubleRedLines", 0)]
+  [InlineData("kerbsideSingleRedLines", 0)]
+  [InlineData("unknown", 1)]
+  public void ValidateGeneralRegulationRegulationType(string regulationType, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -265,17 +264,17 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("free text", 0)]
-    [InlineData("", 1)]
-    [InlineData(null, 1)]
-    public void ValidateRegulationOffListRegulationRegulationFullText(string regulationFullText, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("free text", 0)]
+  [InlineData("", 1)]
+  [InlineData(null, 1)]
+  public void ValidateRegulationOffListRegulationRegulationFullText(string regulationFullText, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -295,17 +294,17 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("free text", 0)]
-    [InlineData("", 1)]
-    [InlineData(null, 1)]
-    public void ValidateRegulationOffListRegulationShortName(string shortName, int errorCount)
-    {
-        DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("free text", 0)]
+  [InlineData("", 1)]
+  [InlineData(null, 1)]
+  public void ValidateRegulationOffListRegulationShortName(string shortName, int errorCount)
+  {
+    DtroSubmit dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""Provision"": [
@@ -325,7 +324,7 @@ public class RegulationValidationTests
           }}
         }}", new SchemaVersion("3.3.0"));
 
-        var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.ValidateRegulation(dtroSubmit, "3.3.0");
+    Assert.Equal(errorCount, actual.Count);
+  }
 }

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/SemanticValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/SemanticValidationServiceTests.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Converters;
 
 namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class SemanticValidationServiceTests
 {
     private readonly Mock<ISystemClock> _mockClock;

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/SourceValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/SourceValidationServiceTests.cs
@@ -1,30 +1,29 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class SourceValidationServiceTests
 {
-    private readonly ISourceValidationService _sut;
+  private readonly ISourceValidationService _sut;
 
-    public SourceValidationServiceTests()
-    {
-        var mockUserRepository = MockUserRepository.Setup();
-        _sut = new SourceValidationService(mockUserRepository.Object);
-    }
+  public SourceValidationServiceTests()
+  {
+    var mockUserRepository = MockUserRepository.Setup();
+    _sut = new SourceValidationService(mockUserRepository.Object);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", "new", 1050, 0)]
-    [InlineData("3.2.4", "amendment", 1050, 0)]
-    [InlineData("3.2.4", "noChange", 1050, 0)]
-    [InlineData("3.2.4", "errorFix", 1050, 0)]
-    [InlineData("3.2.4", "something", 1050, 1)]
-    [InlineData("3.3.0", "new", 1050, 0)]
-    [InlineData("3.3.0", "amendment", 1050, 0)]
-    [InlineData("3.3.0", "noChange", 1050, 0)]
-    [InlineData("3.3.0", "errorFix", 1050, 0)]
-    [InlineData("3.3.0", "something", 1050, 1)]
-    public void ValidateSourceActionType(string version, string actionType, int? traCode, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", "new", 1050, 0)]
+  [InlineData("3.2.4", "amendment", 1050, 0)]
+  [InlineData("3.2.4", "noChange", 1050, 0)]
+  [InlineData("3.2.4", "errorFix", 1050, 0)]
+  [InlineData("3.2.4", "something", 1050, 1)]
+  [InlineData("3.3.0", "new", 1050, 0)]
+  [InlineData("3.3.0", "amendment", 1050, 0)]
+  [InlineData("3.3.0", "noChange", 1050, 0)]
+  [InlineData("3.3.0", "errorFix", 1050, 0)]
+  [InlineData("3.3.0", "something", 1050, 1)]
+  public void ValidateSourceActionType(string version, string actionType, int? traCode, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""{actionType}"",
@@ -37,16 +36,16 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        var actual = _sut.Validate(dtroSubmit, traCode);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.Validate(dtroSubmit, traCode);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", 1050, 0)]
-    [InlineData("3.3.0", 9999, 2)]
-    public void ValidateSourceCurrentTraOwner(string version, int? traCode, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", 1050, 0)]
+  [InlineData("3.3.0", 9999, 2)]
+  public void ValidateSourceCurrentTraOwner(string version, int? traCode, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -59,16 +58,16 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        var actual = _sut.Validate(dtroSubmit, traCode);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.Validate(dtroSubmit, traCode);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", "D5E7FBE5-5A7A-4A81-8E27-CDB008EC729D", 0)]
-    [InlineData("3.3.0", "", 1)]
-    public void ValidateSourceReference(string version, string reference, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", "D5E7FBE5-5A7A-4A81-8E27-CDB008EC729D", 0)]
+  [InlineData("3.3.0", "", 1)]
+  public void ValidateSourceReference(string version, string reference, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -81,17 +80,17 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        int? traCode = 1050;
-        var actual = _sut.Validate(dtroSubmit, traCode);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    int? traCode = 1050;
+    var actual = _sut.Validate(dtroSubmit, traCode);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", "some free text", 0)]
-    [InlineData("3.3.0", "", 1)]
-    public void ValidateSourceSection(string version, string section, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", "some free text", 0)]
+  [InlineData("3.3.0", "", 1)]
+  public void ValidateSourceSection(string version, string section, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -104,21 +103,21 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        int? traCode = 1050;
-        var actual = _sut.Validate(dtroSubmit, traCode);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    int? traCode = 1050;
+    var actual = _sut.Validate(dtroSubmit, traCode);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", "1050, 4, 3300", 0)]
-    [InlineData("3.2.4", "", 1)]
-    [InlineData("3.2.4", "9999, 0, 10000", 1)]
-    [InlineData("3.3.0", "1050, 4, 3300", 0)]
-    [InlineData("3.3.0", "", 1)]
-    [InlineData("3.3.0", "9999, 0, 10000", 1)]
-    public void ValidateSourceTraAffected(string version, string traAffected, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", "1050, 4, 3300", 0)]
+  [InlineData("3.2.4", "", 1)]
+  [InlineData("3.2.4", "9999, 0, 10000", 1)]
+  [InlineData("3.3.0", "1050, 4, 3300", 0)]
+  [InlineData("3.3.0", "", 1)]
+  [InlineData("3.3.0", "9999, 0, 10000", 1)]
+  public void ValidateSourceTraAffected(string version, string traAffected, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -131,16 +130,16 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        var actual = _sut.Validate(dtroSubmit, 1050);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.Validate(dtroSubmit, 1050);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", 1050, 0)]
-    [InlineData("3.3.0", 1000, 2)]
-    public void ValidateSourceTraCreator(string version, int traCode, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", 1050, 0)]
+  [InlineData("3.3.0", 1000, 2)]
+  public void ValidateSourceTraCreator(string version, int traCode, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -153,16 +152,16 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        var actual = _sut.Validate(dtroSubmit, traCode);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.Validate(dtroSubmit, traCode);
+    Assert.Equal(errorCount, actual.Count);
+  }
 
-    [Theory]
-    [InlineData("3.2.4", "D-TRO", 0)]
-    [InlineData("3.3.0", "", 1)]
-    public void ValidateSourceTroName(string version, string troName, int errorCount)
-    {
-        var dtroSubmit = Utils.PrepareDtro($@"
+  [Theory]
+  [InlineData("3.2.4", "D-TRO", 0)]
+  [InlineData("3.3.0", "", 1)]
+  public void ValidateSourceTroName(string version, string troName, int errorCount)
+  {
+    var dtroSubmit = Utils.PrepareDtro($@"
         {{
           ""Source"": {{
             ""actionType"": ""new"",
@@ -175,7 +174,7 @@ public class SourceValidationServiceTests
           }}
         }}", new SchemaVersion(version));
 
-        var actual = _sut.Validate(dtroSubmit, 1050);
-        Assert.Equal(errorCount, actual.Count);
-    }
+    var actual = _sut.Validate(dtroSubmit, 1050);
+    Assert.Equal(errorCount, actual.Count);
+  }
 }

--- a/Src/Dft.DTRO.Tests/ServicesTests/Validations/UniqueStreetReferenceNumberValidationServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/ServicesTests/Validations/UniqueStreetReferenceNumberValidationServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.ServicesTests.Validations;
 
-[ExcludeFromCodeCoverage]
 public class UniqueStreetReferenceNumberValidationServiceTests
 {
     private readonly IUniqueStreetReferenceNumberValidationService _sut =

--- a/Src/Dft.DTRO.Tests/UnitTests/MappingServiceTests.cs
+++ b/Src/Dft.DTRO.Tests/UnitTests/MappingServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.UnitTests;
 
-[ExcludeFromCodeCoverage]
 public class MappingServiceTests
 {
     private static readonly string[] ValidDtroHistoriesFor323 =

--- a/Src/Dft.DTRO.Tests/UnitTests/Proj4SpatialProjectionTests.cs
+++ b/Src/Dft.DTRO.Tests/UnitTests/Proj4SpatialProjectionTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Dft.DTRO.Tests.UnitTests;
 
-[ExcludeFromCodeCoverage]
 public class Proj4SpatialProjectionTests
 {
     private const double ErrorMarginPercent = 1.2;

--- a/Src/Dft.DTRO.Tests/Utils.cs
+++ b/Src/Dft.DTRO.Tests/Utils.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Converters;
 
 namespace Dft.DTRO.Tests;
 
-[ExcludeFromCodeCoverage]
 public static class Utils
 {
     public static DtroSubmit PrepareDtro(string jsonData, SchemaVersion schemaVersion) =>

--- a/run_unit_tests_with_coverage.sh
+++ b/run_unit_tests_with_coverage.sh
@@ -7,7 +7,7 @@ dotnet tool install -g dotnet-reportgenerator-globaltool
   
 dotnet test Src/$PROJECT_NAME/$PROJECT_NAME.csproj --verbosity normal \
 /p:CollectCoverage=true \
-/p:Include="[DfT.DTRO]*" \
+/p:ExcludeByFile=**/*Migrations/*.cs \
 /p:Threshold=$LINE_THRESHOLD /p:ThresholdType=line \
 /p:CoverletOutput=Coverage/coverage.json \
 /p:CoverletOutputFormat=opencover && \

--- a/run_unit_tests_with_coverage.sh
+++ b/run_unit_tests_with_coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LINE_THRESHOLD="40.44"
+LINE_THRESHOLD="40.47"
 PROJECT_NAME="Dft.DTRO.Tests"
  
 dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/run_unit_tests_with_coverage.sh
+++ b/run_unit_tests_with_coverage.sh
@@ -10,5 +10,6 @@ dotnet test Src/$PROJECT_NAME/$PROJECT_NAME.csproj --verbosity normal \
 /p:ExcludeByFile=**/*Migrations/*.cs \
 /p:Threshold=$LINE_THRESHOLD /p:ThresholdType=line \
 /p:CoverletOutput=Coverage/coverage.json \
-/p:CoverletOutputFormat=opencover && \
+/p:CoverletOutputFormat=opencover
+
 reportgenerator -reports:Src/$PROJECT_NAME/Coverage/coverage.json -targetdir:TestReports/UnitTests -reporttypes:Html


### PR DESCRIPTION
## Summary

With help from @Gabriel-Popescu, I've managed to refactor the coverage config and logic.

## Proposed changes

1. Remove [ExcludeFromCodeCoverage] from unit and integration test files (these files seem to be excluded by coverlet automatically).
2. Remove [ExcludeFromCodeCoverage] from migration scripts and exclude these files by using ExcludeByFile.
3. Update the bash script to generate the coverage report regardless of whether coverage is met or not.

Note:
However hard I tried, I couldn't get coverlet to accept more than one value for ExcludeByFile and still fail the build if the threshold for line coverage wasn't met; I tried using a command and using a runsettings.xml file but to no avail.

## Ticket

https://jira.paconsultingatlassian.com/browse/DPPB-1122
