### PR TITLE
Feature/dppb 1215 retire rules and get schema by id endpoints

### DIFF
--- a/Src/DfT.DTRO/Properties/launchSettings.json
+++ b/Src/DfT.DTRO/Properties/launchSettings.json
@@ -6,8 +6,7 @@
       "launchUrl": "index.html",
       "applicationUrl": "https://localhost:5001",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "GOOGLE_APPLICATION_CREDENTIALS": "/Users/fareed.faisal/Downloads/dft-dtro-dev-01-505586f7d88f.json"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "DfT.DTRO-Test": {

--- a/apigee/openApi/openapi3_0.yaml
+++ b/apigee/openApi/openapi3_0.yaml
@@ -348,8 +348,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
         - name: TraCode
           in: query
@@ -915,8 +913,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       responses:
         '200':
@@ -948,8 +944,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       responses:
         '200':
@@ -983,8 +977,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       requestBody:
         description: Object containing a metric request.
@@ -1044,8 +1036,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       requestBody:
         description: Object containing a metric request.
@@ -1115,8 +1105,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       responses:
         '200':
@@ -1136,8 +1124,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
       responses:
         '200':
@@ -1157,8 +1143,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
         - name: version
           in: path
@@ -1184,8 +1168,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
         - name: ruleId
           in: path
@@ -1411,8 +1393,6 @@ paths:
       security:
         - oAuth:
             - cso
-            - dsp
-            - dc
       parameters:
         - name: schemaId
           in: path
@@ -1808,6 +1788,10 @@ paths:
       tags:
         - Users
       summary: Retrieve user list for user
+      operationId: get-users
+      security:
+        - oAuth:
+            - cso
       parameters:
         - name: Page
           in: query
@@ -1852,6 +1836,10 @@ paths:
       tags:
         - Users
       summary: Deletes a user
+      operationId: delete-user
+      security:
+        - oAuth:
+            - cso
       parameters:
         - name: userId
           in: path


### PR DESCRIPTION
## Summary

Retire all /rules and GET /schemas/{id} endpoints

## Proposed changes

- update security oauth scopes for /rules and GET /schemas/{id} endpoints to remove publisher and consumer access in openAPI specification. 
- update scopes for other cso only endpoints to prevent unauthorised access by other user groups
- 

## Ticket

https://jira.paconsultingatlassian.com/browse/DPPB-1215

## Test Evidence

 
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/e61a288a-fd03-4819-ab71-bdbc22a91598" />

